### PR TITLE
Change jval DateTime conversion to use round-trip format

### DIFF
--- a/src/FsJson/FsJson.fs
+++ b/src/FsJson/FsJson.fs
@@ -353,7 +353,7 @@ let rec jval (o:obj) =
     | :? int as i           -> JsonInt i
     | :? float as f         -> JsonFloat f
     | :? float32 as f       -> JsonFloat (safeFloat f)
-    | :? DateTime as d      -> JsonString (d.ToString("s"))
+    | :? DateTime as d      -> JsonString (d.ToString("o"))
     | :? bool as b          -> JsonBool b
     | :? Json as j          -> j
     | :? Guid as g          -> JsonString (g.ToString())


### PR DESCRIPTION
Fix for issue #10.  In addition to retaining the milliseconds, it will also retain the timezone offset.
